### PR TITLE
Adds a few enhancements to per instance infinite precision

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -644,8 +644,9 @@ class Money
 
   private
 
-  def dup_with_new_fractional(new_fractional)
-    self.class.new(new_fractional, currency, { bank: bank, infinite_precision: infinite_precision? })
+  def dup_with_new_fractional(new_fractional, infinite_precision = nil)
+    infinite_precision = self.infinite_precision? if infinite_precision.nil?
+    self.class.new(new_fractional, currency, { bank: bank, infinite_precision: infinite_precision })
   end
 
   def as_d(num)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -124,6 +124,16 @@ class Money
     attr_accessor :default_bank, :default_formatting_rules,
       :use_i18n, :default_infinite_precision, :conversion_precision,
       :locale_backend
+
+    def infinite_precision
+      warn '[DEPRECATION] `Money.infinite_precision` is deprecated - use `Money.default_infinite_precision` instead'
+      self.default_infinite_precision
+    end
+
+    def infinite_precision=(value)
+      warn '[DEPRECATION] `Money.infinite_precision=` is deprecated - use `Money.default_infinite_precision= ` instead'
+      self.default_infinite_precision = value
+    end
   end
 
   # @!attribute default_currency

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -320,6 +320,7 @@ class Money
     @bank     ||= Money.default_bank
     @infinite_precision = obj.respond_to?(:infinite_precision?) ? obj.infinite_precision? : options[:infinite_precision]
     @infinite_precision = self.class.default_infinite_precision if @infinite_precision.nil?
+    @infinite_precision = !!@infinite_precision # ensure we have a boolean
 
     # BigDecimal can be Infinity and NaN, money of that amount does not make sense
     raise ArgumentError, 'must be initialized with a finite value' unless @fractional.finite?
@@ -405,7 +406,7 @@ class Money
   end
 
   def infinite_precision?
-    !!@infinite_precision
+    @infinite_precision
   end
 
   # Common inspect function

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -132,7 +132,8 @@ class Money
         when Money
           other = other.exchange_to(currency)
           new_fractional = fractional.public_send(op, other.fractional)
-          dup_with_new_fractional(new_fractional)
+          infinite_precision = self.infinite_precision? || other.infinite_precision?
+          dup_with_new_fractional(new_fractional, infinite_precision )
         when CoercedNumeric
           raise TypeError, non_zero_message.call(other.value) unless other.zero?
           dup_with_new_fractional(other.value.public_send(op, fractional))
@@ -226,7 +227,8 @@ class Money
     def divmod_money(val)
       cents = val.exchange_to(currency).cents
       quotient, remainder = fractional.divmod(cents)
-      [quotient, dup_with_new_fractional(remainder)]
+      infinite_precision = self.infinite_precision? || val.infinite_precision?
+      [quotient, dup_with_new_fractional(remainder, infinite_precision)]
     end
     private :divmod_money
 

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -213,6 +213,18 @@ describe Money::Arithmetic do
       expect(Money.new(10_00) + 0).to eq Money.new(10_00)
     end
 
+    it "preserves the highest precision of the operands" do
+      high_precision_money = Money.new(10.7654, "USD", { infinite_precision: true })
+      low_precision_money = Money.new(10, "USD", { infinite_precision: false })
+      answer_money = Money.new(20.7654, "USD", { infinite_precision: true })
+      expect((high_precision_money + low_precision_money).infinite_precision?).to eq true
+      expect(high_precision_money + low_precision_money).to eq answer_money
+      expect((low_precision_money + high_precision_money).infinite_precision?).to eq true
+      expect(low_precision_money + high_precision_money).to eq answer_money
+      expect((low_precision_money + low_precision_money).infinite_precision?).to eq false
+      expect(low_precision_money + low_precision_money).to eq Money.new(20, "USD", { infinite_precision: false })
+    end
+
     it "preserves the class in the result when using a subclass of Money" do
       special_money_class = Class.new(Money)
       expect(special_money_class.new(10_00, "USD") + Money.new(90, "USD")).to be_a special_money_class
@@ -242,6 +254,17 @@ describe Money::Arithmetic do
 
     it "subtract Integer 0 to money and returns the same ammount" do
       expect(Money.new(10_00) - 0).to eq Money.new(10_00)
+    end
+
+    it "preserves the highest precision of the operands" do
+      high_precision_money = Money.new(10.7654, "USD", { infinite_precision: true })
+      low_precision_money = Money.new(10, "USD", { infinite_precision: false })
+      expect((high_precision_money - low_precision_money).infinite_precision?).to eq true
+      expect(high_precision_money - low_precision_money).to eq Money.new(0.7654, "USD", { infinite_precision: true })
+      expect((low_precision_money - high_precision_money).infinite_precision?).to eq true
+      expect(low_precision_money - high_precision_money).to eq Money.new(-0.7654, "USD", { infinite_precision: true })
+      expect((low_precision_money - low_precision_money).infinite_precision?).to eq false
+      expect(low_precision_money - low_precision_money).to eq Money.new(0, "USD", { infinite_precision: false })
     end
 
     it "preserves the class in the result when using a subclass of Money" do
@@ -374,7 +397,7 @@ describe Money::Arithmetic do
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "uses BigDecimal division" do
         ts = [
           {a: Money.new( 13, :USD), b: 4, c: Money.new( 3.25, :USD)},
@@ -429,7 +452,7 @@ describe Money::Arithmetic do
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "uses BigDecimal division" do
         ts = [
           {a: Money.new( 13, :USD), b: 4, c: Money.new( 3.25, :USD)},
@@ -482,13 +505,29 @@ describe Money::Arithmetic do
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "uses BigDecimal division" do
         ts = [
             {a: Money.new( 13, :USD), b: 4, c: [Money.new( 3, :USD), Money.new( 1, :USD)]},
             {a: Money.new( 13, :USD), b: -4, c: [Money.new(-4, :USD), Money.new(-3, :USD)]},
             {a: Money.new(-13, :USD), b: 4, c: [Money.new(-4, :USD), Money.new( 3, :USD)]},
             {a: Money.new(-13, :USD), b: -4, c: [Money.new( 3, :USD), Money.new(-1, :USD)]},
+            # {a: Money.new( 10, :USD), b: 3.1, c: [Money.new( 3, :USD), Money.new( 0.7, :USD)]},
+            # {a: Money.new( 10, :USD), b: -3.1 , c: [Money.new( -4, :USD), Money.new( -2.4, :USD)]},
+            # {a: Money.new( -10, :USD), b: 3.1 , c: [Money.new( -4, :USD), Money.new( 2.4, :USD)]},
+            # {a: Money.new( -10, :USD), b: -3.1 , c: [Money.new( 3, :USD), Money.new( -0.7, :USD)]},
+        ]
+        ts.each do |t|
+          expect(t[:a].divmod(t[:b])).to eq t[:c]
+        end
+      end
+    end
+
+    context "with mixed precision" do
+      it "it maintains infinite precision" do
+        ts = [
+          {a: Money.new( 12.99, :USD, {infinite_precision: true}), b: Money.new( 3, :USD), c: [ BigDecimal(4), Money.new( 0.99, :USD, {infinite_precision: true})]},
+          {a: Money.new( 13, :USD), b: Money.new(3.5, :USD, {infinite_precision: true}), c: [ BigDecimal(3), Money.new(2.5, :USD, {infinite_precision: true})]},
         ]
         ts.each do |t|
           expect(t[:a].divmod(t[:b])).to eq t[:c]

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -512,10 +512,6 @@ describe Money::Arithmetic do
             {a: Money.new( 13, :USD), b: -4, c: [Money.new(-4, :USD), Money.new(-3, :USD)]},
             {a: Money.new(-13, :USD), b: 4, c: [Money.new(-4, :USD), Money.new( 3, :USD)]},
             {a: Money.new(-13, :USD), b: -4, c: [Money.new( 3, :USD), Money.new(-1, :USD)]},
-            # {a: Money.new( 10, :USD), b: 3.1, c: [Money.new( 3, :USD), Money.new( 0.7, :USD)]},
-            # {a: Money.new( 10, :USD), b: -3.1 , c: [Money.new( -4, :USD), Money.new( -2.4, :USD)]},
-            # {a: Money.new( -10, :USD), b: 3.1 , c: [Money.new( -4, :USD), Money.new( 2.4, :USD)]},
-            # {a: Money.new( -10, :USD), b: -3.1 , c: [Money.new( 3, :USD), Money.new( -0.7, :USD)]},
         ]
         ts.each do |t|
           expect(t[:a].divmod(t[:b])).to eq t[:c]

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -173,7 +173,7 @@ describe Money, "formatting" do
         end
 
         it "displays a decimal part when infinite_precision is true on the instance" do
-          expect(Money.new(10_00.1, "VUV", nil, true).format).to eq "Vt1,000.1"
+          expect(Money.new(10_00.1, "VUV", { infinite_precision: true }).format).to eq "Vt1,000.1"
         end
       end
 
@@ -184,7 +184,7 @@ describe Money, "formatting" do
         end
 
         it "does not display a decimal part when infinite_precision is false on the instance" do
-          expect(Money.new(10_00.1, "VUV", nil, false).format).to eq "Vt1,000"
+          expect(Money.new(10_00.1, "VUV", { infinite_precision: false }).format).to eq "Vt1,000"
         end
       end
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -118,7 +118,7 @@ describe Money do
 
     context "with infinite_precision on the instance only" do
       let(:initializing_value) { 1.50 }
-      subject(:money) { Money.new(initializing_value, nil, nil, true) }
+      subject(:money) { Money.new(initializing_value, nil, { infinite_precision: true }) }
 
       it "should have the correct cents" do
         expect(money.cents).to eq BigDecimal('1.50')
@@ -192,10 +192,10 @@ describe Money do
 
     it  "does not round the given amount when infinite_precision is set " \
         "on the instance" do
-      expect(Money.from_amount(4.444, "USD", nil, true).amount).to eq "4.444".to_d
-      expect(Money.from_amount(5.555, "USD", nil, true).amount).to eq "5.555".to_d
-      expect(Money.from_amount(444.4, "JPY", nil, true).amount).to eq "444.4".to_d
-      expect(Money.from_amount(555.5, "JPY", nil, true).amount).to eq "555.5".to_d
+      expect(Money.from_amount(4.444, "USD", { infinite_precision: true }).amount).to eq "4.444".to_d
+      expect(Money.from_amount(5.555, "USD", { infinite_precision: true }).amount).to eq "5.555".to_d
+      expect(Money.from_amount(444.4, "JPY", { infinite_precision: true }).amount).to eq "444.4".to_d
+      expect(Money.from_amount(555.5, "JPY", { infinite_precision: true }).amount).to eq "555.5".to_d
     end
 
     it "accepts an optional currency" do
@@ -431,7 +431,7 @@ YAML
       end
 
       it "returns a BigDecimal when infinite_precision is set on instance" do
-        money = Money.new(100, "EUR", nil, true)
+        money = Money.new(100, "EUR", { infinite_precision: true })
         expect(money.round_to_nearest_cash_value).to be_a BigDecimal
       end
     end
@@ -444,7 +444,7 @@ YAML
       end
 
       it "returns an Integer when infinite_precision is set to false on instance" do
-        money = Money.new(100, "EUR", nil, false)
+        money = Money.new(100, "EUR", { infinite_precision: false })
         expect(money.round_to_nearest_cash_value).to be_a Integer
       end
     end


### PR DESCRIPTION
This PR should address the following:
* Updates Money constructor to accept an options hash
* Adds `Money.infinite_precision` accessor aliases for backwards compatibility
* When arithmetic is performed between two Money objects preserves the highest precision

**Note**: It is probably easiest to review this PR commit by commit.

Let me know if I anything needs cleanup or if I missed anything.